### PR TITLE
Hook in check-conf in LSB-friendly way

### DIFF
--- a/etc/init.d/arno-iptables-firewall
+++ b/etc/init.d/arno-iptables-firewall
@@ -51,6 +51,11 @@ if [ "$VERBOSE" = "0" ]; then
       exit $?
     ;;
 
+    configtest)
+      $PROGRAM check-conf
+      exit $?
+    ;;
+
     *)
       $PROGRAM
       exit 1


### PR DESCRIPTION
The current implementation is confusing. The usage message talks about a check-conf, that the init script doesn't understand. The more accepted word for the functionality seems to be configtest, so use that.
