### PR TITLE
changed: Use which output instead of its return code to determine whether a binary exists

### DIFF
--- a/share/arno-iptables-firewall/environment
+++ b/share/arno-iptables-firewall/environment
@@ -73,11 +73,11 @@ check_command()
       return 0
     fi
 
-    if which "$cmd" >/dev/null 2>&1; then
+    if [ -n "$(which "$cmd" 2>/dev/null)" ]; then
       return 0
     fi
   done
-  
+
   return 1
 }
 


### PR DESCRIPTION
Apparently using the return code of which is not reliable on ALL platforms
