### PR TITLE
Parasitic plugin improvements

### DIFF
--- a/bin/arno-iptables-firewall
+++ b/bin/arno-iptables-firewall
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-MY_VERSION="2.0.2a"
+MY_VERSION="2.0.3-DEVEL"
 
 # Location of the main configuration file for the firewall
 ##########################################################
@@ -12,7 +12,7 @@ CONFIG_FILE=/etc/arno-iptables-firewall/firewall.conf
 #
 #                           ~ In memory of my dear father ~
 #
-# (C) Copyright 2001-2017 by Arno van Amersfoort & Lonnie Abelbeck
+# (C) Copyright 2001-2018 by Arno van Amersfoort & Lonnie Abelbeck
 # Homepage              : http://rocky.eld.leidenuniv.nl/
 # Email                 : a r n o v a AT r o c k y DOT e l d DOT l e i d e n u n i v DOT n l
 #                         (note: you must remove all spaces and substitute the @ and the .

--- a/etc/arno-iptables-firewall/plugins/parasitic-net.conf
+++ b/etc/arno-iptables-firewall/plugins/parasitic-net.conf
@@ -23,19 +23,17 @@ ENABLED=0
 # (IPv4 Only)
 # ------------------------------------------------------------------------------
 
+# Specify which (external) network interfaces should have parasitic SNAT enabled
+# Leave empty to include all external interfaces
+# ------------------------------------------------------------------------------
+PARASITIC_NET_IF=""
+
 # Specify which "clients" on your subnet that are allowed to use this device
 # as a gateway. Define IPv4 addresses, IPv4 address ranges or a small CIDR.
 # Example: "192.168.1.10 192.168.1.15 192.168.1.20-30"
 # Must be defined, there is no default.
 # ------------------------------------------------------------------------------
 PARASITIC_NET_CLIENT_HOSTS=""
-
-# The default external gateway interface is obtained from the first interface
-# defined in the EXT_IF variable.
-# Use PARASITIC_NET_IF to specify a different EXT_IF interface.
-# Note: The PARASITIC_NET_CLIENT_HOSTS must be on this gateway interface subnet.
-# ------------------------------------------------------------------------------
-PARASITIC_NET_IF=""
 
 ################################################################################
 # Use PARASITIC_NET_HOST_OPEN_xxx and PARASITIC_NET_HOST_DENY to restrict      #

--- a/etc/arno-iptables-firewall/plugins/parasitic-net.conf
+++ b/etc/arno-iptables-firewall/plugins/parasitic-net.conf
@@ -77,6 +77,10 @@ PARASITIC_NET_HOST_DENY_UDP=""
 PARASITIC_NET_HOST_DENY_ICMP=""
 PARASITIC_NET_HOST_DENY_IP=""
 
-# Enable (1) logging of denied Parasitic Network packets
+# Enable (1) or disable(0) logging of denied packets
 # ------------------------------------------------------------------------------
 PARASITIC_NET_DENY_LOG=1
+
+# Specify the policy for denied packets: DROP (default) or REJECT
+# ------------------------------------------------------------------------------
+PARASITIC_NET_DENY_POLICY="DROP"

--- a/etc/arno-iptables-firewall/plugins/parasitic-net.conf
+++ b/etc/arno-iptables-firewall/plugins/parasitic-net.conf
@@ -30,10 +30,10 @@ ENABLED=0
 # ------------------------------------------------------------------------------
 PARASITIC_NET_IF=""
 
-# Specify which "clients" on your subnet that are allowed to use this device
-# as a gateway. Define IPv4 addresses, IPv4 address ranges or a small CIDR.
-# Example: "192.168.1.10 192.168.1.15 192.168.1.20-30"
-# Must be defined, there is no default.
+# Specify which "clients" are allowed to use this device as an SNAT gateway.
+# If not specified all hosts on parasitic SNAT enabled interfaces are allowed
+# NOTE: The hosts in here should be on subnets connected to interfaces specified
+# in PARASITIC_NET_IF
 # ------------------------------------------------------------------------------
 PARASITIC_NET_CLIENT_HOSTS=""
 

--- a/etc/arno-iptables-firewall/plugins/parasitic-net.conf
+++ b/etc/arno-iptables-firewall/plugins/parasitic-net.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#           -= Arno's iptables firewall - Parasitic Network plugin =-
+#       -= Arno's iptables firewall - Parasitic (SNAT) Network plugin =-
 # ------------------------------------------------------------------------------
 
 # To actually enable this plugin make ENABLED=1:
@@ -24,7 +24,7 @@ ENABLED=0
 # ------------------------------------------------------------------------------
 
 # Specify which "clients" on your subnet that are allowed to use this device
-# as a gateway.  Define IPv4 addresses, IPv4 address ranges or a small CIDR.
+# as a gateway. Define IPv4 addresses, IPv4 address ranges or a small CIDR.
 # Example: "192.168.1.10 192.168.1.15 192.168.1.20-30"
 # Must be defined, there is no default.
 # ------------------------------------------------------------------------------
@@ -37,22 +37,48 @@ PARASITIC_NET_CLIENT_HOSTS=""
 # ------------------------------------------------------------------------------
 PARASITIC_NET_IF=""
 
-# By default all Parasitic Network packets are forwarded and NAT'ed upstream.
-# Use PARASITIC_NET_ALLOW_HOSTS and PARASITIC_NET_DENY_HOSTS to restrict
-# forwarded Parasitic Network traffic.
-#
-# Tip: Whitelisting can be performed by setting PARASITIC_NET_DENY_HOSTS="0/0"
-#      and setting PARASITIC_NET_ALLOW_HOSTS to the only allowed hosts.
-#
-# PARASITIC_NET_ALLOW_HOSTS used in conjunction with PARASITIC_NET_DENY_HOSTS,
-# otherwise the default policy is to allow.
-# ------------------------------------------------------------------------------
-PARASITIC_NET_ALLOW_HOSTS=""
+################################################################################
+# Use PARASITIC_NET_HOST_OPEN_xxx and PARASITIC_NET_HOST_DENY to restrict      #
+# forwarded parasitic network traffic.                                         #
+#                                                                              #
+# By default all parasitic network packets are forwarded and NAT'ed upstream,  #
+# unless one of the PARASATIC_NET_HOST_OPEN_xxx variables is specified. In     #
+# that case the default policy for that protocol (TCP, UDP, ICMP, IP) will     #
+# become deny, except for IP which always defaults to deny.                    #
+################################################################################
 
-# Deny Parasitic Network packets to specified hosts, networks
+# Put in the following variables which hosts you want to allow(open) for certain
+# services
+# TCP/UDP port format (PARASITIC_NET_HOST_OPEN_TCP & PARASITIC_NET_HOST_OPEN_UDP):
+#       "host1,host2~port1,port2 host3,host4~port3,port4 ..."
+#
+# ICMP protocol format (PARASITIC_NET_HOST_OPEN_ICMP):
+#       "host1 host2 ...." 
+#
+# IP protocol format (PARASITIC_NET_HOST_OPEN_IP):
+#       "host1,host2~proto1,proto2 host3,host4~proto4,proto4 ..."
 # ------------------------------------------------------------------------------
-PARASITIC_NET_DENY_HOSTS=""
+PARASITIC_NET_HOST_OPEN_TCP=""
+PARASITIC_NET_HOST_OPEN_UDP=""
+PARASITIC_NET_HOST_OPEN_ICMP=""
+PARASITIC_NET_HOST_OPEN_IP=""
+
+# Put in the following variables which hosts you want to deny for certain
+# services
+# TCP/UDP port format (PARASITIC_NET_HOST_DENY_TCP & PARASITIC_NET_HOST_DENY_UDP):
+#       "host1,host2~port1,port2 host3,host4~port3,port4 ..."
+#
+# ICMP protocol format (PARASITIC_NET_HOST_DENY_ICMP):
+#       "host1 host2 ...." 
+#
+# IP protocol format (PARASITIC_NET_HOST_DENY_IP):
+#       "host1,host2~proto1,proto2 host3,host4~proto4,proto4 ..."
+# ------------------------------------------------------------------------------
+PARASITIC_NET_HOST_DENY_TCP=""
+PARASITIC_NET_HOST_DENY_UDP=""
+PARASITIC_NET_HOST_DENY_ICMP=""
+PARASITIC_NET_HOST_DENY_IP=""
 
 # Enable (1) logging of denied Parasitic Network packets
 # ------------------------------------------------------------------------------
-PARASITIC_NET_DENY_LOG=0
+PARASITIC_NET_DENY_LOG=1

--- a/etc/arno-iptables-firewall/plugins/parasitic-net.conf
+++ b/etc/arno-iptables-firewall/plugins/parasitic-net.conf
@@ -24,7 +24,9 @@ ENABLED=0
 # ------------------------------------------------------------------------------
 
 # Specify which (external) network interfaces should have parasitic SNAT enabled
-# Leave empty to include all external interfaces
+# You can optionally also provide the interface IP in the form of interface~IP
+# (for eg. interfaces with multiple IP addresses). Multiple interfaces should
+# be space separated. Leave empty to include all external interfaces
 # ------------------------------------------------------------------------------
 PARASITIC_NET_IF=""
 

--- a/share/arno-iptables-firewall/environment
+++ b/share/arno-iptables-firewall/environment
@@ -4,7 +4,7 @@
 #
 #                           ~ In memory of my dear father ~
 #
-# (C) Copyright 2001-2017 by Arno van Amersfoort & Lonnie Abelbeck
+# (C) Copyright 2001-2018 by Arno van Amersfoort & Lonnie Abelbeck
 # Homepage              : http://rocky.eld.leidenuniv.nl/
 # Email                 : a r n o v a AT r o c k y DOT e l d DOT l e i d e n u n i v DOT n l
 #                         (note: you must remove all spaces and substitute the @ and the .
@@ -1086,7 +1086,7 @@ get_ifs()
 }
 
 
-# Helper function to get source/destination IP(s) from variable
+# Helper function to get source/destination interface IP(s) from variable
 get_ips()
 {
   local result=""
@@ -1588,7 +1588,7 @@ progress_bar()
 }
 
 
-# Check existance of an interface
+# Check existence of an interface
 check_interface()
 {
   local interface IFS=' '
@@ -1614,26 +1614,39 @@ check_interface()
   return 1
 }
 
-# Get IP address/mask of specified network interface
-get_network_ipv4_address_mask()
+# Get all IP address(es)/mask(s) of specified network interface
+get_network_ipv4_address_mask_all()
 {
   ip -o addr show dev "$1" 2>/dev/null \
-    |awk '$3 == "inet" { print $4; exit; }'
+    |awk '$3 == "inet" { print $4 }' |tr '\n' ' ' |sed s,' $',,
 }
 
-# Get IP address of the specified network interface
+# Get (primary) IP address/mask of specified network interface
+get_network_ipv4_address_mask()
+{
+  get_network_ipv4_address_mask_all "$1" |cut -d' ' -f1
+}
+
+# Get all IP address(es) of the specified network interface
+get_network_ipv4_address_all()
+{
+  ip -o addr show dev "$1" 2>/dev/null \
+    |awk '$3 == "inet" { print $4 }' |cut -f1 -d'/' |tr '\n' ' ' |sed s,' $',,
+}
+
+# Get (primary) IP address of the specified network interface
 get_network_ipv4_address()
 {
   get_network_ipv4_address_mask "$1" |cut -f1 -d'/'
 }
 
-# Get netmask of the specified network interface 
+# Get (primary) netmask of the specified network interface
 get_network_ipv4_mask()
 {
   get_network_ipv4_address_mask "$1" |cut -f2 -d'/'
 }
 
-# Get broadcast address of the specified network interface 
+# Get broadcast address of the specified network interface
 get_network_ipv4_broadcast()
 {
   ip -o addr show dev "$1" 2>/dev/null \
@@ -1653,7 +1666,7 @@ get_network_ipv6_address()
   get_network_ipv6_address_mask "$1" |cut -f1 -d'/'
 }
 
-# Get IPv6 netmask of the specified network interface 
+# Get IPv6 netmask of the specified network interface
 get_network_ipv6_mask()
 {
   get_network_ipv6_address_mask "$1" |cut -f2 -d'/'
@@ -1842,4 +1855,3 @@ if [ -z "$EXTERNAL_NET" -a -n "$EXT_IF" ]; then
     done
   done
 fi
-

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -330,6 +330,12 @@ plugin_stop()
 # Plugin status function
 plugin_status()
 {
+  echo "  Interface forward policy:"
+  echo "  =============================="
+  ip4tables -nv -L POST_FORWARD_CHAIN | awk '$3 == "PARASITIC_NET_FORWARD" { print "  "$3" "$6" "$7" "$8" "$9 }'
+  echo "  ------------------------------"
+  echo ""
+
   echo "  Allowed client host(s):"
   echo "  =============================="
   ip4tables -n -L PARASITIC_NET_FORWARD | awk '$1 == "PARASITIC_NET_ACL" { print "  "$4 }'

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -39,7 +39,7 @@ PLUGIN_CONF_FILE="parasitic-net.conf"
 # Plugin start function
 plugin_start()
 {
-  local IFS x host interface if_ip snat_if snat_ip snat_ifs_ips snat_ip_out
+  local IFS x host interface if_ip snat_if snat_ip snat_ifs_ips snat_ip_out snat_if_subnet
 
   ip4tables -t nat -N PARASITIC_NET_SNAT 2>/dev/null
   ip4tables -t nat -F PARASITIC_NET_SNAT
@@ -80,6 +80,15 @@ plugin_start()
   fi
 
   echo "${INDENT}Parasitic network SNAT interface(s)/address(es): $snat_ifs_ips"
+
+  if [ -z "$PARASITIC_NET_CLIENT_HOSTS" ]; then
+    IFS=' ,'
+    for if_ip in $(wildcard_ifs $PARASITIC_NET_IF); do
+      snat_if="$(echo "$if_ip" |cut -d'~' -f1)"
+      snat_if_subnet="$(get_network_ipv4_address_mask_all $snat_if)"
+      PARASITIC_NET_CLIENT_HOSTS="$PARASITIC_NET_CLIENT_HOSTS${PARASITIC_NET_CLIENT_HOSTS:+ }$snat_if_subnet"
+    done
+  fi
 
   # Setup Parasitic Network ACL rules
   ###################################
@@ -340,23 +349,7 @@ plugin_status()
 # Check sanity of eg. environment
 plugin_sanity_check()
 {
-  local IFS if1 if2 host
-
-  # Sanity check
-  if [ -z "$PARASITIC_NET_CLIENT_HOSTS" ]; then
-    printf "\033[40m\033[1;31m${INDENT}ERROR: PARASITIC_NET_CLIENT_HOSTS is not set!\033[0m\n" >&2
-    return 1
-  fi
-
-  IFS=' ,'
-  for host in $PARASITIC_NET_CLIENT_HOSTS; do
-    case $host in
-      */0) printf "\033[40m\033[1;31m${INDENT}ERROR: */0 networks are not allowed in PARASITIC_NET_CLIENT_HOSTS.\033[0m\n" >&2
-           printf "\033[40m\033[1;31m${INDENT}       Be restrictive when defining PARASITIC_NET_CLIENT_HOSTS.   \033[0m\n" >&2
-           return 1
-           ;;
-    esac
-  done
+  local IFS if1 if2
 
   if [ -n "$PARASITIC_NET_DENY_POLICY" -a "$PARASITIC_NET_DENY_POLICY" != "DROP" -a "$PARASITIC_NET_DENY_POLICY" != "REJECT" ]; then
     printf "\033[40m\033[1;31m${INDENT}ERROR: PARASITIC_NET_DENY_POLICY must be either \"DROP\" (or left empty) or \"REJECT\"!\033[0m\n" >&2

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -5,7 +5,7 @@ PLUGIN_NAME="Parasitic (SNAT) Network plugin"
 PLUGIN_VERSION="1.00-BETA2"
 PLUGIN_CONF_FILE="parasitic-net.conf"
 #
-# Last changed          : April 5, 2018
+# Last changed          : April 6, 2018
 # Requirements          : AIF 2.0.3+
 # Comments              : This plugin allows "clients" on the same subnet to use this
 #                         device as a gateway upstream. This network of "clients" is
@@ -39,7 +39,7 @@ PLUGIN_CONF_FILE="parasitic-net.conf"
 # Plugin start function
 plugin_start()
 {
-  local IFS x host interface if_ip snat_if snat_ip snat_ifs_ips snat_ip_out snat_if_subnet
+  local IFS host interface if_ip snat_if snat_ip snat_ifs_ips snat_if_subnet
 
   ip4tables -t nat -N PARASITIC_NET_SNAT 2>/dev/null
   ip4tables -t nat -F PARASITIC_NET_SNAT
@@ -279,14 +279,13 @@ plugin_start()
   done
 
   IFS=' '
-  for x in $snat_ifs_ips; do
-    snat_if="$(echo "$x" |cut -d'~' -f1)"
+  for if_ip in $snat_ifs_ips; do
+    snat_if="$(echo "$if_ip" |cut -d'~' -f1)"
+    snat_ip="$(echo "$if_ip" |cut -d'~' -f2)"
 
     IFS=' ,'
     for host in $(ip_range $PARASITIC_NET_CLIENT_HOSTS); do
-      # Use primary(!) IPv4 address for SNAT output
-      snat_ip_out="$(get_network_ipv4_address $snat_if)"
-      ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host -j SNAT --to-source $snat_ip_out
+      ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host -j SNAT --to-source $snat_ip
     done
   done
 
@@ -420,4 +419,3 @@ else
     fi
   fi
 fi
-

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -1,23 +1,23 @@
 # ------------------------------------------------------------------------------
-#           -= Arno's iptables firewall - Parasitic Network plugin =-
+#       -= Arno's iptables firewall - Parasitic (SNAT) Network plugin =-
 #
-PLUGIN_NAME="Parasitic Network plugin"
-PLUGIN_VERSION="1.00 BETA"
+PLUGIN_NAME="Parasitic (SNAT) Network plugin"
+PLUGIN_VERSION="1.00-BETA2"
 PLUGIN_CONF_FILE="parasitic-net.conf"
 #
-# Last changed          : July 25, 2017
+# Last changed          : March 15, 2018
 # Requirements          : AIF 2.0.1+
 # Comments              : This plugin allows "clients" on the same subnet to use this
 #                       : device as a gateway upstream. This network of "clients" is
 #                       : SNAT'ed to this device's external interface(s).
 #                       : 
-#                       : This Parasitic Network is useful for situations when the
+#                       : This parasitic network is useful for situations when the
 #                       : upstream firewall is not under your control and you desire
 #                       : added security for specific devices in your subnet.
-#                       : Set the gateway address of Parasitic Network clients to an
+#                       : Set the gateway address of parasitic network clients to an
 #                       : external IPv4 address of this device.
 #
-# Author                : (C) Copyright 2017 by Arno van Amersfoort & Lonnie Abelbeck
+# Author                : (C) Copyright 2017-2018 by Arno van Amersfoort & Lonnie Abelbeck
 # Email                 : arnova AT rocky DOT eld DOT leidenuniv DOT nl
 #                         (note: you must remove all spaces and substitute the @ and the .
 #                         at the proper locations!)
@@ -94,34 +94,179 @@ plugin_start()
     return 1
   fi
 
-  echo "${INDENT}Parasitic Network Gateway IPv4 Address: $gateway_ip"
+  echo "${INDENT}Parasitic network gateway IPv4 address: $gateway_ip"
 
-  echo "${INDENT}Parasitic Network Gateway Interface: $gateway_if"
+  echo "${INDENT}Parasitic network gateway interface: $gateway_if"
+
+  echo "${INDENT}Setting up ACLs"
 
   # Setup Parasitic Network ACL rules
-  if [ -n "$PARASITIC_NET_ALLOW_HOSTS" ]; then
-    echo "${INDENT}Allowing Parasitic Network packets to hosts: $PARASITIC_NET_ALLOW_HOSTS"
-    IFS=' ,'
-    for host in $PARASITIC_NET_ALLOW_HOSTS; do
-      ip4tables -A PARASITIC_NET_ACL -d $host -j ACCEPT
-    done
-  fi
-  if [ -n "$PARASITIC_NET_DENY_HOSTS" ]; then
-    echo "${INDENT}Denying Parasitic Network packets to hosts: $PARASITIC_NET_DENY_HOSTS"
-    IFS=' ,'
-    for host in $PARASITIC_NET_DENY_HOSTS; do
+  ###################################
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_DENY_TCP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_DENY_TCP "hosts-ports"; then
+      echo "${INDENT} Denying access to $hosts for TCP port(s): $ports"
+
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for port in $ports; do
+          if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+            ip4tables -A PARASITIC_NET_ACL -d $host -p tcp --dport $port -m limit --limit 1/m -j LOG \
+              --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+          fi
+
+          ip4tables -A PARASITIC_NET_ACL -d $host -p tcp --dport $port -j DROP
+        done
+      done
+    fi
+  done
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_DENY_UDP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_DENY_UDP "hosts-ports"; then
+      echo "${INDENT} Denying access to $hosts for UDP port(s): $ports"
+
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for port in $ports; do
+          if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+            ip4tables -A PARASITIC_NET_ACL -d $host -p udp --dport $port -m limit --limit 1/m -j LOG \
+              --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+          fi
+
+          ip4tables -A PARASITIC_NET_ACL -d $host -p udp --dport $port -j DROP
+        done
+      done
+    fi
+  done
+
+  IFS=' ,'
+  for hosts in $PARASITIC_NET_HOST_DENY_ICMP; do
+    echo "${INDENT} Denying access to $hosts for ICMP requests"
+
+    for host in `ip_range "$hosts"`; do
       if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
-        ip4tables -A PARASITIC_NET_ACL -d $host -m limit --limit 1/m -j LOG \
-                 --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-Net denied: "
+        ip4tables -A PARASITIC_NET_ACL -d $host -p icmp --icmp-type echo-request -m limit --limit 1/m -j LOG \
+          --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
       fi
-      ip4tables -A PARASITIC_NET_ACL -d $host -j DROP
+
+      ip4tables -A PARASITIC_NET_ACL -d $host -p icmp --icmp-type echo-request -j DROP
     done
+  done
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_DENY_IP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_DENY_IP "hosts-protos"; then
+      echo "${INDENT} Denying access to $hosts for IP protocol(s): $protos"
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for proto in $protos; do
+          if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+            ip4tables -A PARASITIC_NET_ACL -d $host -p $proto -m limit --limit 1/m -j LOG \
+              --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+          fi
+
+          ip4tables -A PARASITIC_NET_ACL -d $host -p $proto -j DROP
+        done
+      done
+    fi
+  done
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_OPEN_TCP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_OPEN_TCP "hosts-ports"; then
+      echo "${INDENT} Allowing access to $hosts for TCP port(s): $ports"
+
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for port in $ports; do
+          ip4tables -A PARASITIC_NET_ACL -d $host -p tcp --dport $port -j ACCEPT
+        done
+      done
+    fi
+  done
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_OPEN_UDP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_OPEN_UDP "hosts-ports"; then
+      echo "${INDENT} Allowing access to $hosts for UDP port(s): $ports"
+
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for port in $ports; do
+          ip4tables -A PARASITIC_NET_ACL -d $host -p udp --dport $port -j ACCEPT
+        done
+      done
+    fi
+  done
+
+  IFS=' ,'
+  for hosts in $PARASITIC_NET_HOST_OPEN_ICMP; do
+    echo "${INDENT} Allowing access to $hosts for ICMP requests"
+
+    for host in `ip_range "$hosts"`; do
+      ip4tables -A PARASITIC_NET_ACL -d $host -p icmp --icmp-type echo-request -j ACCEPT
+    done
+  done
+
+  unset IFS
+  for rule in $PARASITIC_NET_HOST_OPEN_IP; do
+    if parse_rule "$rule" PARASITIC_NET_HOST_OPEN_IP "hosts-protos"; then
+      echo "${INDENT} Allowing access to $hosts for IP protocol(s): $protos"
+
+      IFS=','
+      for host in `ip_range "$hosts"`; do
+        for proto in $protos; do
+          ip4tables -A PARASITIC_NET_ACL -d $host -p $proto -j ACCEPT
+        done
+      done
+    fi
+  done
+
+  # Set default policy
+  if [ -z "$PARASITIC_NET_HOST_OPEN_TCP" ]; then
+    ip4tables -A PARASITIC_NET_ACL -p tcp -j ACCEPT
+  else
+    if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+      ip4tables -A PARASITIC_NET_ACL -p tcp -m limit --limit 1/m -j LOG \
+        --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+    fi
+
+    ip4tables -A PARASITIC_NET_ACL -p tcp -j DROP
   fi
-  # Default policy, allow all the rest
-  ip4tables -A PARASITIC_NET_ACL -j ACCEPT
+
+  if [ -z "$PARASITIC_NET_HOST_OPEN_UDP" ]; then
+    ip4tables -A PARASITIC_NET_ACL -p udp -j ACCEPT
+  else
+    if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+      ip4tables -A PARASITIC_NET_ACL -p udp -m limit --limit 1/m -j LOG \
+        --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+    fi
+
+    ip4tables -A PARASITIC_NET_ACL -p udp -j DROP
+  fi
+
+  if [ -z "$PARASITIC_NET_HOST_OPEN_ICMP" ]; then
+    ip4tables -A PARASITIC_NET_ACL -p icmp --icmp-type echo-request -j ACCEPT
+  else
+    if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+      ip4tables -A PARASITIC_NET_ACL -p icmp --icmp-type echo-request -m limit --limit 1/m -j LOG \
+        --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+    fi
+
+    ip4tables -A PARASITIC_NET_ACL -p icmp --icmp-type echo-request -j DROP
+  fi
+
+  # Drop the rest ("Other" IP protocols always need to be specified explicitly)
+  if [ "$PARASITIC_NET_DENY_LOG" = "1" ]; then
+    ip4tables -A PARASITIC_NET_ACL -m limit --limit 1/m -j LOG \
+      --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
+  fi
+  ip4tables -A PARASITIC_NET_ACL -j DROP
 
   # Filter traffic related to the Parasitic Network
-  echo "${INDENT}Allowing Parasitic Network client access for host(s): $PARASITIC_NET_CLIENT_HOSTS"
+  echo "${INDENT}Allowing parasitic network access for client host(s): $PARASITIC_NET_CLIENT_HOSTS"
   IFS=' ,'
   for host in $(ip_range $PARASITIC_NET_CLIENT_HOSTS); do
     if [ "$host" != "$gateway_ip" ]; then
@@ -201,7 +346,7 @@ plugin_status()
   echo "  ------------------------------"
   echo ""
   
-  echo "  Access Control List:"
+  echo "  Access Control List(ACL):"
   echo "  =============================="
   ip4tables -n -L PARASITIC_NET_ACL | sed -n -e 's/^ACCEPT.*$/  &/p' -e 's/^DROP.*$/  &/p'
   echo "  ------------------------------"

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -5,8 +5,8 @@ PLUGIN_NAME="Parasitic (SNAT) Network plugin"
 PLUGIN_VERSION="1.00-BETA2"
 PLUGIN_CONF_FILE="parasitic-net.conf"
 #
-# Last changed          : March 19, 2018
-# Requirements          : AIF 2.0.1+
+# Last changed          : March 22, 2018
+# Requirements          : AIF 2.0.3+
 # Comments              : This plugin allows "clients" on the same subnet to use this
 #                         device as a gateway upstream. This network of "clients" is
 #                         SNAT'ed to this device's external interface(s).
@@ -36,22 +36,10 @@ PLUGIN_CONF_FILE="parasitic-net.conf"
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 # ------------------------------------------------------------------------------
 
-parasitic_net_first_ipv4()
-{
-  ip -o addr show dev "$1" 2>/dev/null \
-    | awk '$3 == "inet" { split($4, field, "/"); print field[1]; nextfile; }'
-}
-
-parasitic_net_all_ipv4()
-{
-  ip -o addr show dev "$1" 2>/dev/null \
-    | awk '$3 == "inet" { split($4, field, "/"); print field[1]; }'
-}
-
 # Plugin start function
 plugin_start()
 {
-  local x host interface if_ip snat_if snat_ip snat_ifs_ips IFS
+  local IFS x host interface if_ip snat_if snat_ip snat_ifs_ips snat_ip_out
 
   ip4tables -t nat -N PARASITIC_NET_SNAT 2>/dev/null
   ip4tables -t nat -F PARASITIC_NET_SNAT
@@ -72,10 +60,16 @@ plugin_start()
 
   snat_ifs_ips=""
   IFS=' ,'
-  for interface in $(wildcard_ifs $PARASITIC_NET_IF); do
-    snat_if="$interface"
-    snat_ip="$(parasitic_net_first_ipv4 $interface)"
-    if [ -n "$snat_if" -a -n "$snat_ip" ]; then
+  for if_ip in $(wildcard_ifs $PARASITIC_NET_IF); do
+    snat_if="$(echo "$if_ip" |cut -d'~' -f1)"
+    snat_ip="$(echo "$if_ip" |cut -s -d'~' -f2)"
+
+    if [ -z "$snat_ip" ]; then
+      # Add all interface IPs to list
+      for if_ip in $(get_network_ipv4_address_all $snat_if); do
+        snat_ifs_ips="$snat_ifs_ips${snat_ifs_ips:+ }$snat_if~$if_ip"
+      done
+    else
       snat_ifs_ips="$snat_ifs_ips${snat_ifs_ips:+ }$snat_if~$snat_ip"
     fi
   done
@@ -263,27 +257,27 @@ plugin_start()
   # Enable forwarding on the SNAT interfaces.
   # Note: can't check IF IP here, therefore only match interface(s)
   IFS=' ,'
-  for snat_if in $(wildcard_ifs $PARASITIC_NET_IF); do
+  for if_ip in $(wildcard_ifs $PARASITIC_NET_IF); do
+    snat_if="$(echo "$if_ip" |cut -d'~' -f1)"
     ip4tables -A POST_FORWARD_CHAIN -i $snat_if -o $snat_if -j PARASITIC_NET_FORWARD
   done
 
-  # Actual SNAT, we do not want traffic generated on this machine to be NAT-ed, skip all snat_if IPv4's
-  unset IFS
-  for x in $snat_ifs_ips; do
-    snat_if="$(echo "$x" | cut -d'~' -f1)"
-    unset IFS
-    for if_ip in $(parasitic_net_all_ipv4 $snat_if); do
-      ip4tables -t nat -A PARASITIC_NET_SNAT -s $if_ip -j RETURN
-    done
+  # We do not want traffic generated on this machine to be NAT-ed, so skip all SNAT interface IPv4's
+  IFS=' '
+  for if_ip in $snat_ifs_ips; do
+    snat_ip="$(echo "$if_ip" |cut -d'~' -f2)"
+    ip4tables -t nat -A PARASITIC_NET_SNAT -s $snat_ip -j RETURN
   done
 
-  unset IFS
+  IFS=' '
   for x in $snat_ifs_ips; do
-    snat_if="$(echo "$x" | cut -d'~' -f1)"
-    snat_ip="$(echo "$x" | cut -d'~' -f2)"
+    snat_if="$(echo "$x" |cut -d'~' -f1)"
+
     IFS=' ,'
     for host in $(ip_range $PARASITIC_NET_CLIENT_HOSTS); do
-      ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host -j SNAT --to-source $snat_ip
+      # Use primary(!) IPv4 address for SNAT output
+      snat_ip_out="$(get_network_ipv4_address $snat_if)"
+      ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host -j SNAT --to-source $snat_ip_out
     done
   done
 

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -66,6 +66,10 @@ plugin_start()
     PARASITIC_NET_IF="$EXT_IF"
   fi
 
+  if [ -z "$PARASITIC_NET_DENY_POLICY" ]; then
+    PARASITIC_NET_DENY_POLICY="DROP"
+  fi
+
   snat_ifs_ips=""
   IFS=' ,'
   for interface in $(wildcard_ifs $PARASITIC_NET_IF); do
@@ -100,7 +104,7 @@ plugin_start()
               --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
           fi
 
-          ip4tables -A PARASITIC_NET_ACL -d $host -p tcp --dport $port -j DROP
+          ip4tables -A PARASITIC_NET_ACL -d $host -p tcp --dport $port -j $PARASITIC_NET_DENY_POLICY
         done
       done
     fi
@@ -119,7 +123,7 @@ plugin_start()
               --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
           fi
 
-          ip4tables -A PARASITIC_NET_ACL -d $host -p udp --dport $port -j DROP
+          ip4tables -A PARASITIC_NET_ACL -d $host -p udp --dport $port -j $PARASITIC_NET_DENY_POLICY
         done
       done
     fi
@@ -135,7 +139,7 @@ plugin_start()
           --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
       fi
 
-      ip4tables -A PARASITIC_NET_ACL -d $host -p icmp --icmp-type echo-request -j DROP
+      ip4tables -A PARASITIC_NET_ACL -d $host -p icmp --icmp-type echo-request -j $PARASITIC_NET_DENY_POLICY
     done
   done
 
@@ -151,7 +155,7 @@ plugin_start()
               --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
           fi
 
-          ip4tables -A PARASITIC_NET_ACL -d $host -p $proto -j DROP
+          ip4tables -A PARASITIC_NET_ACL -d $host -p $proto -j $PARASITIC_NET_DENY_POLICY
         done
       done
     fi
@@ -217,7 +221,7 @@ plugin_start()
         --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
     fi
 
-    ip4tables -A PARASITIC_NET_ACL -p tcp -j DROP
+    ip4tables -A PARASITIC_NET_ACL -p tcp -j $PARASITIC_NET_DENY_POLICY
   fi
 
   if [ -z "$PARASITIC_NET_HOST_OPEN_UDP" ]; then
@@ -228,7 +232,7 @@ plugin_start()
         --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
     fi
 
-    ip4tables -A PARASITIC_NET_ACL -p udp -j DROP
+    ip4tables -A PARASITIC_NET_ACL -p udp -j $PARASITIC_NET_DENY_POLICY
   fi
 
   if [ -z "$PARASITIC_NET_HOST_OPEN_ICMP" ]; then
@@ -239,7 +243,7 @@ plugin_start()
         --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
     fi
 
-    ip4tables -A PARASITIC_NET_ACL -p icmp --icmp-type echo-request -j DROP
+    ip4tables -A PARASITIC_NET_ACL -p icmp --icmp-type echo-request -j $PARASITIC_NET_DENY_POLICY
   fi
 
   # Drop the rest ("Other" IP protocols always need to be specified explicitly)
@@ -247,7 +251,7 @@ plugin_start()
     ip4tables -A PARASITIC_NET_ACL -m limit --limit 1/m -j LOG \
       --log-level $LOGLEVEL --log-prefix "AIF:Parasitic-net denied: "
   fi
-  ip4tables -A PARASITIC_NET_ACL -j DROP
+  ip4tables -A PARASITIC_NET_ACL -j $PARASITIC_NET_DENY_POLICY
 
   # Filter traffic related to the Parasitic Network
   echo "${INDENT}Allowing parasitic network access for client host(s): $PARASITIC_NET_CLIENT_HOSTS"
@@ -359,6 +363,11 @@ plugin_sanity_check()
            ;;
     esac
   done
+
+  if [ -n "$PARASITIC_NET_DENY_POLICY" -a "$PARASITIC_NET_DENY_POLICY" != "DROP" -a "$PARASITIC_NET_DENY_POLICY" != "REJECT" ]; then
+    printf "\033[40m\033[1;31m${INDENT}ERROR: PARASITIC_NET_DENY_POLICY must be either \"DROP\" (or left empty) or \"REJECT\"!\033[0m\n" >&2
+    return 1
+  fi
 
   IFS=' ,'
   for if1 in $INT_IF $DMZ_IF; do

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -5,7 +5,7 @@ PLUGIN_NAME="Parasitic (SNAT) Network plugin"
 PLUGIN_VERSION="1.00-BETA2"
 PLUGIN_CONF_FILE="parasitic-net.conf"
 #
-# Last changed          : March 22, 2018
+# Last changed          : April 5, 2018
 # Requirements          : AIF 2.0.3+
 # Comments              : This plugin allows "clients" on the same subnet to use this
 #                         device as a gateway upstream. This network of "clients" is
@@ -341,7 +341,7 @@ plugin_status()
   ip4tables -n -L PARASITIC_NET_FORWARD | awk '$1 == "PARASITIC_NET_ACL" { print "  "$4 }'
   echo "  ------------------------------"
   echo ""
-  
+
   echo "  Access Control List(ACL):"
   echo "  =============================="
   ip4tables -n -L PARASITIC_NET_ACL | sed -n -e 's/^ACCEPT.*$/  &/p' -e 's/^DROP.*$/  &/p'
@@ -420,3 +420,4 @@ else
     fi
   fi
 fi
+

--- a/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
+++ b/share/arno-iptables-firewall/plugins/20parasitic-net.plugin
@@ -5,17 +5,17 @@ PLUGIN_NAME="Parasitic (SNAT) Network plugin"
 PLUGIN_VERSION="1.00-BETA2"
 PLUGIN_CONF_FILE="parasitic-net.conf"
 #
-# Last changed          : March 15, 2018
+# Last changed          : March 19, 2018
 # Requirements          : AIF 2.0.1+
 # Comments              : This plugin allows "clients" on the same subnet to use this
-#                       : device as a gateway upstream. This network of "clients" is
-#                       : SNAT'ed to this device's external interface(s).
-#                       : 
-#                       : This parasitic network is useful for situations when the
-#                       : upstream firewall is not under your control and you desire
-#                       : added security for specific devices in your subnet.
-#                       : Set the gateway address of parasitic network clients to an
-#                       : external IPv4 address of this device.
+#                         device as a gateway upstream. This network of "clients" is
+#                         SNAT'ed to this device's external interface(s).
+#                         This parasitic network is useful for situations when the
+#                         upstream firewall is not under your control and you desire
+#                         added security for specific devices in your subnet.
+#                         Set the gateway address of parasitic network clients to an
+#                         external IPv4 address of this device. Note that this plugin
+#                         only works for IPv4, NOT IPv6
 #
 # Author                : (C) Copyright 2017-2018 by Arno van Amersfoort & Lonnie Abelbeck
 # Email                 : arnova AT rocky DOT eld DOT leidenuniv DOT nl
@@ -51,7 +51,7 @@ parasitic_net_all_ipv4()
 # Plugin start function
 plugin_start()
 {
-  local x host net eif gateway_if gateway_ip snat_if snat_ip snat_ifs_ips IFS
+  local x host interface if_ip snat_if snat_ip snat_ifs_ips IFS
 
   ip4tables -t nat -N PARASITIC_NET_SNAT 2>/dev/null
   ip4tables -t nat -F PARASITIC_NET_SNAT
@@ -62,46 +62,30 @@ plugin_start()
   ip4tables -N PARASITIC_NET_FORWARD 2>/dev/null
   ip4tables -F PARASITIC_NET_FORWARD
 
+  if [ -z "$PARASITIC_NET_IF" ]; then
+    PARASITIC_NET_IF="$EXT_IF"
+  fi
+
   snat_ifs_ips=""
   IFS=' ,'
-  for eif in $(wildcard_ifs $EXT_IF); do
-    snat_if="$eif"
-    snat_ip="$(parasitic_net_first_ipv4 $eif)"
+  for interface in $(wildcard_ifs $PARASITIC_NET_IF); do
+    snat_if="$interface"
+    snat_ip="$(parasitic_net_first_ipv4 $interface)"
     if [ -n "$snat_if" -a -n "$snat_ip" ]; then
       snat_ifs_ips="$snat_ifs_ips${snat_ifs_ips:+ }$snat_if~$snat_ip"
     fi
   done
 
   if [ -z "$snat_ifs_ips" ]; then
-    printf "\033[40m\033[1;31m${INDENT}ERROR: Unable to determine external interface IPv4 address!\033[0m\n" >&2
+    printf "\033[40m\033[1;31m${INDENT}ERROR: Unable to determine SNAT interface(s)/address(es)!\033[0m\n" >&2
     return 1
   fi
 
-  gateway_if=""
-  gateway_ip=""
-  unset IFS
-  for x in $snat_ifs_ips; do
-    eif="$(echo "$x" | cut -d'~' -f1)"
-    if [ -z "$PARASITIC_NET_IF" -o "$eif" = "$PARASITIC_NET_IF" ]; then
-      gateway_if="$eif"
-      gateway_ip="$(echo "$x" | cut -d'~' -f2)"
-      break
-    fi
-  done
-
-  if [ -z "$gateway_if" -o -z "$gateway_ip" ]; then
-    printf "\033[40m\033[1;31m${INDENT}ERROR: Unable to match PARASITIC_NET_IF external gateway interface!\033[0m\n" >&2
-    return 1
-  fi
-
-  echo "${INDENT}Parasitic network gateway IPv4 address: $gateway_ip"
-
-  echo "${INDENT}Parasitic network gateway interface: $gateway_if"
-
-  echo "${INDENT}Setting up ACLs"
+  echo "${INDENT}Parasitic network SNAT interface(s)/address(es): $snat_ifs_ips"
 
   # Setup Parasitic Network ACL rules
   ###################################
+  echo "${INDENT}Setting up ACLs"
 
   unset IFS
   for rule in $PARASITIC_NET_HOST_DENY_TCP; do
@@ -269,14 +253,14 @@ plugin_start()
   echo "${INDENT}Allowing parasitic network access for client host(s): $PARASITIC_NET_CLIENT_HOSTS"
   IFS=' ,'
   for host in $(ip_range $PARASITIC_NET_CLIENT_HOSTS); do
-    if [ "$host" != "$gateway_ip" ]; then
-      ip4tables -A PARASITIC_NET_FORWARD -s $host -j PARASITIC_NET_ACL
-    fi
+    ip4tables -A PARASITIC_NET_FORWARD -s $host -j PARASITIC_NET_ACL
   done
 
+  # Enable forwarding on the SNAT interfaces.
+  # Note: can't check IF IP here, therefore only match interface(s)
   IFS=' ,'
-  for eif in $(wildcard_ifs $EXT_IF); do
-    ip4tables -A FORWARD -i $gateway_if -o $eif -j PARASITIC_NET_FORWARD
+  for snat_if in $(wildcard_ifs $PARASITIC_NET_IF); do
+    ip4tables -A POST_FORWARD_CHAIN -i $snat_if -o $snat_if -j PARASITIC_NET_FORWARD
   done
 
   # Actual SNAT, we do not want traffic generated on this machine to be NAT-ed, skip all snat_if IPv4's
@@ -284,8 +268,8 @@ plugin_start()
   for x in $snat_ifs_ips; do
     snat_if="$(echo "$x" | cut -d'~' -f1)"
     unset IFS
-    for host in $(parasitic_net_all_ipv4 $snat_if); do
-      ip4tables -t nat -A PARASITIC_NET_SNAT -s $host -j RETURN
+    for if_ip in $(parasitic_net_all_ipv4 $snat_if); do
+      ip4tables -t nat -A PARASITIC_NET_SNAT -s $if_ip -j RETURN
     done
   done
 
@@ -295,13 +279,12 @@ plugin_start()
     snat_ip="$(echo "$x" | cut -d'~' -f2)"
     IFS=' ,'
     for host in $(ip_range $PARASITIC_NET_CLIENT_HOSTS); do
-      if [ "$host" != "$snat_ip" ]; then
-        ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host ! -d $host -j SNAT --to-source $snat_ip
-      fi
+      ip4tables -t nat -A PARASITIC_NET_SNAT -o $snat_if -s $host -j SNAT --to-source $snat_ip
     done
   done
 
-  ip4tables -t nat -A POSTROUTING -j PARASITIC_NET_SNAT
+  # Hook into the POST POSTROUTING NAT chain
+  ip4tables -t nat -A POST_NAT_POSTROUTING_CHAIN -j PARASITIC_NET_SNAT
 
   return 0
 }
@@ -322,7 +305,7 @@ plugin_restart()
 plugin_stop()
 {
 
-  ip4tables -t nat -D POSTROUTING -j PARASITIC_NET_SNAT
+  ip4tables -t nat -D POST_NAT_POSTROUTING_CHAIN -j PARASITIC_NET_SNAT
 
   ip4tables -t nat -F PARASITIC_NET_SNAT
   ip4tables -t nat -X PARASITIC_NET_SNAT 2>/dev/null
@@ -359,7 +342,7 @@ plugin_status()
 # Check sanity of eg. environment
 plugin_sanity_check()
 {
-  local host interface IFS
+  local IFS if1 if2 host
 
   # Sanity check
   if [ -z "$PARASITIC_NET_CLIENT_HOSTS" ]; then
@@ -377,15 +360,15 @@ plugin_sanity_check()
     esac
   done
 
-  if [ -n "$PARASITIC_NET_IF" ]; then
-    IFS=' ,'
-    for interface in $INT_IF $DMZ_IF; do
-      if [ "$interface" = "$PARASITIC_NET_IF" ]; then
-        printf "\033[40m\033[1;31m${INDENT}ERROR: INT_IF or DMZ_IF interfaces are not allowed for PARASITIC_NET_IF.\033[0m\n" >&2
+  IFS=' ,'
+  for if1 in $INT_IF $DMZ_IF; do
+    for if2 in $PARASITIC_NET_IF; do
+      if [ "$if1" = "$if2" ]; then
+        printf "\033[40m\033[1;31m${INDENT}ERROR: INT_IF/DMZ_IF interface $if1 is not allowed as PARASITIC_NET_IF interface $if2.\033[0m\n" >&2
         return 1
       fi
     done
-  fi
+  done
 
   return 0
 }

--- a/share/arno-iptables-firewall/plugins/parasitic-net.CHANGELOG
+++ b/share/arno-iptables-firewall/plugins/parasitic-net.CHANGELOG
@@ -1,4 +1,3 @@
 Version 1.00 BETA (July 25, 2017)
 ---------------------------------
 + Initial version
-

--- a/share/arno-iptables-firewall/plugins/parasitic-net.CHANGELOG
+++ b/share/arno-iptables-firewall/plugins/parasitic-net.CHANGELOG
@@ -1,3 +1,12 @@
-Version 1.00 BETA (July 25, 2017)
----------------------------------
+Version 1.00-BETA2 (April 5, 2018)
+-----------------------------------
++ Allow specifying multiple interfaces
++ Allow specifying IP for interfaces to use (aliased) interfaces with multiple IPs
++ Allow specifying subnet for PARASITIC_NET_CLIENTS_HOSTS or leaving it empty
++ Instead of only allowing certain hosts, also allow specifying which TCP/UDP/ICMP/IP protos to allow/deny
++ Add setting to select deny-policy (DROP or REJECT)
+* Misc. tweaks/refactor
+
+Version 1.00-BETA1 (July 25, 2017)
+----------------------------------
 + Initial version


### PR DESCRIPTION
This improves/refactors the parasitic SNAT network plugin. Most important changes:
- It now allows specifying multiple interfaces
- It now allows specifying subnet for PARASITIC_NET_CLIENTS_HOSTS or leaving it empty
- It now allows specifying which TCP/UDP/ICMP/IP protos to allow or DENY
- It now allows specifying the deny-policy (DROP or REJECT)