### PR TITLE
fixed: Make ipt_if() return string match the calling IFS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Version 2.1.0-RC2-DEVEL (February 12, 2019)
 -------------------------------------------
+! ipt_if() expansion didn't work as it should
 * Improve copy/overwrite logic in install.sh
 
 Version 2.1.0-RC1 (February 10, 2019)

--- a/share/arno-iptables-firewall/environment
+++ b/share/arno-iptables-firewall/environment
@@ -1045,7 +1045,7 @@ parse_rule_warning()
 ipt_if()
 {
   if [ -n "$2" -a "$2" != "+" ]; then
-    echo "$1 $2"
+    echo "$1${IFS:- }$2"
   fi
 }
 


### PR DESCRIPTION
The function `ipt_if()` is called with either `IFS=','` or `IFS=' ,'`

Previously, we always returned a `' '` between arguments, which `IFS=','` interprets as part of the returned argument, and an iptables warning.  This was not an issue with `IFS=' ,'`.

In order to make `ipt_if()` work with any calling `IFS` value, use `${IFS:- }` as the argument separator.