### PR TITLE
changed: Get rid of separate FIREWALL_LOG option in firewall.conf

### DIFF
--- a/bin/arno-iptables-firewall
+++ b/bin/arno-iptables-firewall
@@ -6021,24 +6021,18 @@ show_status()
 
 show_start()
 {
-  DATE=`LC_ALL=C date +'%b %d %H:%M:%S'`
-  echo "$DATE ** Starting Arno's Iptables Firewall(AIF) v$MY_VERSION **" >> $FIREWALL_LOG
   echo "** Starting Arno's Iptables Firewall(AIF) v$MY_VERSION **" |log_msg
 }
 
 
 show_restart()
 {
-  DATE=`LC_ALL=C date +'%b %d %H:%M:%S'`
-  echo "$DATE ** Restarting Arno's Iptables Firewall(AIF) v$MY_VERSION **" >> $FIREWALL_LOG
   echo "** Restarting Arno's Iptables Firewall(AIF) v$MY_VERSION **" |log_msg
 }
 
 
 show_failed()
 {
-  DATE=`LC_ALL=C date +'%b %d %H:%M:%S'`
-  echo "$DATE ** ERROR: Firewall failed to start! **" >> $FIREWALL_LOG
   echo "** ERROR: Firewall failed to start! **" |log_msg
 }
 
@@ -6047,7 +6041,6 @@ show_stop()
 {
   DATE=`LC_ALL=C date +'%b %d %H:%M:%S'`
   printf "$DATE \033[40m\033[1;32mStopping Arno's Iptables Firewall(AIF) v$MY_VERSION\033[0m\n"
-  echo "$DATE ** Stopping Arno's Iptables Firewall(AIF) v$MY_VERSION **" >> $FIREWALL_LOG
   echo "** Stopping Arno's Iptables Firewall(AIF) v$MY_VERSION **" |log_msg
 }
 
@@ -6068,11 +6061,9 @@ show_applied()
 
   if [ $RULE_WARNING -ne 0 ]; then
     printf "$DATE \033[40m\033[1;31mWARNING: $RULE_WARNING firewall rules failed to apply!\n\033[0m" >&2
-    echo "$DATE ** WARNING: $RULE_WARNING firewall rules failed to apply! **" >> $FIREWALL_LOG
     echo "** WARNING: $RULE_WARNING firewall rules failed to apply! **" |log_msg
   else
     printf "$DATE \033[40m\033[1;32mAll firewall rules applied.\033[0m\n"
-    echo "$DATE ** All firewall rules applied **" >> $FIREWALL_LOG
     echo "** All firewall rules applied **" |log_msg
   fi
 

--- a/etc/arno-iptables-firewall/firewall.conf
+++ b/etc/arno-iptables-firewall/firewall.conf
@@ -513,17 +513,11 @@ OTHER_IP_LOG=1
 # ------------------------------------------------------------------------------
 ICMP_FLOOD_LOG=1
 
-# (EXPERT SETTING!) The location of the dedicated firewall log file. When
-# enabled the firewall script will also log start/stop etc. info to this file
-# as well. Note that in order to make this work, you should also configure
-# syslogd to log firewall messages to this file (see LOGLEVEL below for further
-# info).
-# ------------------------------------------------------------------------------
-#FIREWALL_LOG="/var/log/firewall.log"
-
-# (EXPERT SETTING!) Current log-level ("info": default kernel syslog level)
-# "debug": can be used to log to /var/log/firewall.log, but you have to
-# configure syslogd accordingly (see included syslogd.conf examples).
+# (EXPERT SETTING!) Log-level used for logging to syslog. The default is "info"
+# but "debug" can be used to have (legacy) syslogd log to /var/log/firewall.log.
+# Note that this also requires you to modify your syslogd.conf (see examples on
+# how to). Most (if not all) newer distributions use rsyslogd which works much
+# better out of the box, so in most cases you can leave this setting as is.
 # ------------------------------------------------------------------------------
 LOGLEVEL="info"
 

--- a/etc/rsyslog.d/arno-iptables-firewall.conf
+++ b/etc/rsyslog.d/arno-iptables-firewall.conf
@@ -6,3 +6,5 @@ if $syslogfacility-text == 'kern' \
 and $msg contains 'AIF:' then -/var/log/firewall.log
 & stop
 
+if $syslogtag == 'firewall:' then -/var/log/firewall.log
+

--- a/share/arno-iptables-firewall/environment
+++ b/share/arno-iptables-firewall/environment
@@ -1870,7 +1870,7 @@ log_msg()
   IFS=$EOL
   while read LINE; do
     # Have sed remove any colouring
-    echo "${PREFIX}${LINE}" |sed 's/\x1B\[[0-9;]\+[A-Za-z]//g' |logger -t firewall -p kern.info
+    echo "${PREFIX}${LINE}" |sed 's/\x1B\[[0-9;]\+[A-Za-z]//g' |logger -t firewall -p user.info
   done
 }
 
@@ -2003,11 +2003,6 @@ PLUGIN_LOAD_FILE_RESTART="/var/tmp/aif_active_plugins_restart"
 
 # (Dynamic) host cache. Used by compatible plugins
 HOST_CACHE_FILE="/var/tmp/aif_host_cache"
-
-# Check whether we also need to drop messages in a dedicated firewall log file
-if [ -z "$FIREWALL_LOG" ]; then
-  FIREWALL_LOG="/dev/null"
-fi
 
 # Check for a local/global config file
 ######################################


### PR DESCRIPTION
Another round of cleanups :-) This was only ever needed when we only had syslogd.....