### PR TITLE
fixed: tweak rule for allowing DHCPv6 client requests

### DIFF
--- a/bin/arno-iptables-firewall
+++ b/bin/arno-iptables-firewall
@@ -2725,7 +2725,7 @@ setup_ext_input_chain()
   if [ "$EXT_IF_DHCP_IP" = "1" -o "$EXT_IF_DHCPV6_IPV6" = "1" ]; then
     if [ "$IPV6_SUPPORT" = "1" ]; then
       # Allow this host to be an DHCPv6 client:
-      ip6tables -A EXT_INPUT_CHAIN -s fe80::/10 -p udp --sport 547 --dport 546 -j ACCEPT
+      ip6tables -A EXT_INPUT_CHAIN -d fe80::/10 -p udp --sport 547 --dport 546 -j ACCEPT
     fi
   fi
 


### PR DESCRIPTION
In 2022, Comcast/Xfinity made a change where a 'dhcp6 reply' source address is global (GUA) not the expected link-local (LLA) source address.
The destination address is link-local, so match the destination address for link-local instead of the source address.

Thanks to David Kerr @dkerr64 for the report.