### PR TITLE
changed: Enable IPv6 name record lookups for dig-wrapper. This indire…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-Version 2.1.1b-DEVEL (June 6, 2023)
+Version 2.1.1b-DEVEL (May 16, 2024)
 -----------------------------------
+* Enable IPv6 name record lookups for dig-wrapper. This indirectly enables IPv6/AAAA-record support for dyndns-host-open (& traffic-accounting) plugin
 ! Prevent systemd from terminating the job manager when some rules fail
 * Renamed xxx_OUTPUT to INET_OUTPUT_xxx for clarity/consistency
 + Additional INET_OUTPUT_xxx settings to have better control

--- a/bin/arno-iptables-firewall
+++ b/bin/arno-iptables-firewall
@@ -12,7 +12,7 @@ CONFIG_FILE=/etc/arno-iptables-firewall/firewall.conf
 #
 #                           ~ In memory of my dear parents ~
 #
-# (C) Copyright 2001-2023 by Arno van Amersfoort & Lonnie Abelbeck
+# (C) Copyright 2001-2024 by Arno van Amersfoort & Lonnie Abelbeck
 # Web                   : https://github.com/arno-iptables-firewall/aif
 # Email                 : a r n o DOT v a n DOT a m e r s f o o r t AT g m a i l DOT c o m
 #                         (note: you must remove all spaces and substitute the @ and the .

--- a/share/arno-iptables-firewall/environment
+++ b/share/arno-iptables-firewall/environment
@@ -710,22 +710,26 @@ ip()
 ####################
 dig()
 {
-  local x=0 addr name lines item retval first IFS
+  local x=0 addr name lines item retval first dig_args IFS
 
   if [ -n "$DIG" ]; then
+    dig_args="+noauthority +noadditional"
+
     if [ "$DNS_FAST_FAIL" = "1" -o "$DNS_FAST_FAIL_ONCE" = "1" ]; then
-      lines="$($DIG +noauthority +noadditional +tries=1 +time=1 "$@" 2>/dev/null)"
-      retval=$?
+      dig_args="$dig_args +tries=1 +time=1"
       DNS_FAST_FAIL_ONCE=0
-    else
-      lines="$($DIG +noauthority +noadditional "$@" 2>/dev/null)"
-      retval=$?
     fi
+
+    if [ "$IPV6_SUPPORT" = "1" ]; then
+      dig_args="$dig_args any"  # To obtain AAAA-record as well
+    fi
+
+    lines="$($DIG $dig_args "$@" 2>/dev/null)"
     retval=$?
 
     first=1
     IFS=$EOL
-    for item in `echo "$lines" |awk '{ if (substr($0,0,1) != ";" && ($4 == "A" || $4 == "PTR")) print $NF }'`; do
+    for item in $(echo "$lines" |awk '{ if (substr($0,0,1) != ";" && ($4 == "A" || $4 == "AAAA" || $4 == "PTR")) print $NF }'); do
       if [ $first -eq 1 ]; then
         first=0
       else


### PR DESCRIPTION
…ctly enables IPv6/AAAA-record support for the dyndns-host-open (& traffic-accounting) plugin.

@abelbeck : Please review, should be a no-brainer (why didn't we enable this before? ;-)).